### PR TITLE
feat: support reading page.attributes.updated

### DIFF
--- a/packages/saber/lib/Pages.js
+++ b/packages/saber/lib/Pages.js
@@ -61,7 +61,9 @@ module.exports = class Pages extends Map {
     // So we set them after the transformers
 
     // Read createdAt from page attribute
-    // Or fallback to the date in fileName or the birthtime of the file
+    // Or fallback to `page.attributes.date` (Hexo compatibility)
+    // Or fallback to the date in fileName
+    // Or fallback to the `file.birthtime`
     page.attributes.createdAt = new Date(
       page.attributes.createdAt ||
         page.attributes.date ||
@@ -69,9 +71,12 @@ module.exports = class Pages extends Map {
         file.birthtime
     )
 
-    // Read updatedAt from page.attribute.updated (Hexo compatibility)
-    // Or fallback to file.mtime
-    page.attributes.updatedAt = new Date(page.attributes.updated || file.mtime)
+    // Read updatedAt from page attribute
+    // Or fallback to `page.attributes.updated` (Hexo compatibility)
+    // Or fallback to `file.mtime`
+    page.attributes.updatedAt = new Date(
+      page.attributes.updatedAt || page.attributes.updated || file.mtime
+    )
 
     page.attributes.type =
       page.attributes.type || getPageType(file.relative, page.attributes.slug)

--- a/packages/saber/lib/Pages.js
+++ b/packages/saber/lib/Pages.js
@@ -68,12 +68,10 @@ module.exports = class Pages extends Map {
         parsedFileName[2] ||
         file.birthtime
     )
-    
-    // Read updatedAt from page.attribute.updated
+
+    // Read updatedAt from page.attribute.updated (Hexo compatibility)
     // Or fallback to file.mtime
-    page.attributes.updatedAt = new Date(
-      page.attributes.updated || file.mtime
-    )
+    page.attributes.updatedAt = new Date(page.attributes.updated || file.mtime)
 
     page.attributes.type =
       page.attributes.type || getPageType(file.relative, page.attributes.slug)

--- a/packages/saber/lib/Pages.js
+++ b/packages/saber/lib/Pages.js
@@ -30,8 +30,7 @@ module.exports = class Pages extends Map {
 
     const page = {
       attributes: {
-        slug,
-        updatedAt: file.mtime
+        slug
       },
       internal: {
         id: hash(file.absolute),
@@ -68,6 +67,12 @@ module.exports = class Pages extends Map {
         page.attributes.date ||
         parsedFileName[2] ||
         file.birthtime
+    )
+    
+    // Read updatedAt from page.attribute.updated
+    // Or fallback to file.mtime
+    page.attributes.updatedAt = new Date(
+      page.attributes.updated || file.mtime
     )
 
     page.attributes.type =

--- a/website/pages/docs/page-interface.md
+++ b/website/pages/docs/page-interface.md
@@ -32,13 +32,13 @@ interface Page {
      * If the page is loaded from file system
      * It defaults to `attributes.date` || `birthtime` of the file
      */
-    createdAt?: Date | string
+    createdAt?: Date
     /**
      * The updated time of this page
      * If the page is loaded from file system
-     * It defaults to the `mtime` of the file
+     * It defaults to `attributes.updated` || `mtime` of the file
      */
-    updatedAt?: Date | string
+    updatedAt?: Date
     /**
      * The permalink to the page
      * We infer it from `internal.relative` if it's loaded from file system


### PR DESCRIPTION
User can specific the updated date of the content.
```markdown
---
layout: post
updated: 2019-03-31 10:20:30
---

I just opened the markdown file and hit save, but didn't change the content of this post.
I don't want to change the `updatedAt` of the post by using `file.mtime`, since the post
did not update. I want it use the `updated` field I provided in front-matter.
```