### PR TITLE
 feat(generate-feed): support xml format of feed

### DIFF
--- a/packages/saber-plugin-generate-feed/README.md
+++ b/packages/saber-plugin-generate-feed/README.md
@@ -1,0 +1,74 @@
+# saber-plugin-generate-feed
+
+Generate feed in Atom 1.0 or RSS 2.0 or JSON format.
+
+## Install
+
+```bash
+yarn add saber-plugin-generate-feed
+```
+
+## Usage
+
+In your `saber-config.yml`:
+
+```yml
+plugins:
+  - resolve: saber-plugin-generate-feed
+    options:
+      # Generate atom.xml
+      atomFeed: true
+      # Generate rss2.xml
+      rss2Feed: true
+      # Generate feed.json
+      jsonFeed: true
+```
+
+### Saber Variables
+
+This plugin will also inject some useful Saber variables you can use at runtime:
+
+```js
+import variables from 'saber/variables'
+
+variables.feedLinks
+// { rss2?: string, json?: string, atom?: string }
+
+variables.feedLink
+// The link to preferred feed
+// Atom > RSS2 > JSON
+```
+
+## Options
+
+### atomFeed
+
+- Type: `string` `boolean`
+- Default: `undefined`
+
+The output path of the Atom feed, when `true` it outputs to `atom.xml`.
+
+### rss2Feed
+
+- Type: `string` `boolean`
+- Default: `undefined`
+
+The output path of the RSS2 feed, when `true` it outputs to `rss2.xml`.
+
+### jsonFeed
+
+- Type: `string` `boolean`
+- Default: `undefined`
+
+The output path of the JSON feed, when `true` it outputs to `feed.json`.
+
+### limit
+
+- Type: `number`
+- Default: `30`
+
+The maximum amount of posts to include in the feed.
+
+## License
+
+MIT.

--- a/packages/saber-plugin-generate-feed/example/saber-config.yml
+++ b/packages/saber-plugin-generate-feed/example/saber-config.yml
@@ -1,5 +1,9 @@
 plugins:
   - resolve: ../
+    options:
+      atomFeed: true
+      rss2Feed: true
+      jsonFeed: blog/feed.json
 
 siteConfig:
   url: https://exampe.com

--- a/packages/saber-plugin-generate-feed/lib/index.js
+++ b/packages/saber-plugin-generate-feed/lib/index.js
@@ -38,11 +38,12 @@ exports.apply = (api, options = {}) => {
     const posts = []
     for (const page of api.pages.values()) {
       if (page.attributes.type === 'post' && !page.attributes.draft) {
+        const { excerpt } = page.attributes
         posts.push({
           title: page.attributes.title,
           id: page.attributes.permalink,
           link: url.resolve(siteConfig.url, page.attributes.permalink),
-          description: page.attributes.description,
+          description: excerpt && excerpt.replace(/<(?:.|\n)*?>/gm, ''),
           content: page.content,
           date: page.attributes.updatedAt,
           published: page.attributes.createdAt

--- a/packages/saber-plugin-generate-feed/lib/index.js
+++ b/packages/saber-plugin-generate-feed/lib/index.js
@@ -1,58 +1,96 @@
 /* eslint-disable camelcase */
-const url = require('url')
+const urljoin = require('url-join')
+const Feed = require('feed').Feed
 
 const ID = 'generate-feed'
 
 exports.name = ID
 
-exports.apply = (api, { limit = 30 } = {}) => {
+exports.apply = (api, options = {}) => {
+  // Plugin options
+  options = Object.assign({
+    limit: 30,
+    generator: 'Feed for Saberjs',
+    copyright: 'All rights reserved'
+  }, options)
+
   const { siteConfig } = api.config
   if (!siteConfig.url) {
     throw new Error(`siteConfig.url is required for saber-plugin-generate-feed`)
   }
-  const feedUrl = url.resolve(siteConfig.url, 'feed.json')
+
+  // All type of feed links
+  const feedLinks = options.feeds
+    ? options.feeds
+    : {
+      json: urljoin(siteConfig.url, 'feed.json'),
+      atom: urljoin(siteConfig.url, 'atom.xml')
+    }
 
   api.hooks.afterGenerate.tapPromise(ID, async () => {
+    // Prepare posts
     const posts = []
-
     for (const page of api.pages.values()) {
       if (page.attributes.type === 'post' && !page.attributes.draft) {
         posts.push({
           title: page.attributes.title,
           id: page.attributes.permalink,
-          url: url.resolve(siteConfig.url, page.attributes.permalink),
-          content_html: page.content,
-          date_published: new Date(page.attributes.createdAt),
-          date_modified: page.attributes.updatedAt
+          link: urljoin(siteConfig.url, page.attributes.permalink),
+          description: page.attributes.description,
+          content: page.content,
+          date: page.attributes.updatedAt,
+          published: page.attributes.createdAt
         })
       }
     }
+    // Order by published
     const items = posts
       .sort((a, b) => {
-        return a.date_published > b.date_published ? -1 : 1
+        return b.published - a.published
       })
-      .slice(0, limit)
-    if (items.length > 0) {
-      const feed = {
-        version: 'https://jsonfeed.org/version/1',
-        title: siteConfig.title,
-        description: siteConfig.description,
-        author:
-          typeof siteConfig.author === 'string'
-            ? {
-                name: siteConfig.author
-              }
-            : siteConfig.author,
-        home_page_url: siteConfig.url,
-        feed_url: feedUrl,
-        items
-      }
-      const { log } = api
-      const { fs } = api.utils
-      log.info(`Generating feed.json`)
+      .slice(0, options.limit)
+
+    // Feed instance
+    const feed = new Feed({
+      title: siteConfig.title,
+      description: siteConfig.description,
+      id: siteConfig.url,
+      link: siteConfig.url,
+      copyright: options.copyright,
+      generator: options.generator,
+      author:
+        typeof siteConfig.author === 'string'
+          ? {
+            name: siteConfig.author
+          }
+          : siteConfig.author,
+      feedLinks: feedLinks
+    })
+
+    // Add posts to feed
+    items.forEach(post => {
+      feed.addItem(post)
+    })
+
+    const { log } = api
+    const { fs } = api.utils
+
+    // JSON
+    if (feedLinks.json) {
+      log.info('Generating json feed')
       await fs.outputFile(
-        api.resolveCwd('.saber/public/feed.json'),
-        JSON.stringify(feed),
+        api.resolveCwd(`.saber/public/${feedLinks.json.replace(siteConfig.url, '')}`),
+        feed.json1(),
+        'utf8'
+      )
+    }
+
+    // Atom and RSS2 (Note: rss2 also uses atom to generate)
+    if (feedLinks.atom || feedLinks.rss2) {
+      log.info('Generating xml feed')
+      await fs.outputFile(
+        api.resolveCwd(`.saber/public/${feedLinks.atom.replace(siteConfig.url, '')}`),
+        feed.atom1(),
         'utf8'
       )
     }
@@ -61,7 +99,7 @@ exports.apply = (api, { limit = 30 } = {}) => {
   api.hooks.defineVariables.tap(ID, variables => {
     return Object.assign(variables, {
       feed: true,
-      feedURL: feedUrl
+      feedLinks: feedLinks
     })
   })
 }

--- a/packages/saber-plugin-generate-feed/lib/index.js
+++ b/packages/saber-plugin-generate-feed/lib/index.js
@@ -43,6 +43,7 @@ exports.apply = (api, options = {}) => {
           title: page.attributes.title,
           id: page.attributes.permalink,
           link: url.resolve(siteConfig.url, page.attributes.permalink),
+          // Strip HTML tags in excerpt and use it as description (a.k.a. summary)
           description: excerpt && excerpt.replace(/<(?:.|\n)*?>/gm, ''),
           content: page.content,
           date: page.attributes.updatedAt,

--- a/packages/saber-plugin-generate-feed/lib/index.js
+++ b/packages/saber-plugin-generate-feed/lib/index.js
@@ -1,6 +1,5 @@
-/* eslint-disable camelcase */
 const urljoin = require('url-join')
-const Feed = require('feed').Feed
+const { Feed } = require('feed')
 
 const ID = 'generate-feed'
 
@@ -8,11 +7,14 @@ exports.name = ID
 
 exports.apply = (api, options = {}) => {
   // Plugin options
-  options = Object.assign({
-    limit: 30,
-    generator: 'Feed for Saberjs',
-    copyright: 'All rights reserved'
-  }, options)
+  options = Object.assign(
+    {
+      limit: 30,
+      generator: 'Feed for Saberjs',
+      copyright: 'All rights reserved'
+    },
+    options
+  )
 
   const { siteConfig } = api.config
   if (!siteConfig.url) {
@@ -23,9 +25,9 @@ exports.apply = (api, options = {}) => {
   const feedLinks = options.feeds
     ? options.feeds
     : {
-      json: urljoin(siteConfig.url, 'feed.json'),
-      atom: urljoin(siteConfig.url, 'atom.xml')
-    }
+        json: urljoin(siteConfig.url, 'feed.json'),
+        atom: urljoin(siteConfig.url, 'atom.xml')
+      }
 
   api.hooks.afterGenerate.tapPromise(ID, async () => {
     // Prepare posts
@@ -61,10 +63,10 @@ exports.apply = (api, options = {}) => {
       author:
         typeof siteConfig.author === 'string'
           ? {
-            name: siteConfig.author
-          }
+              name: siteConfig.author
+            }
           : siteConfig.author,
-      feedLinks: feedLinks
+      feedLinks
     })
 
     // Add posts to feed
@@ -79,7 +81,9 @@ exports.apply = (api, options = {}) => {
     if (feedLinks.json) {
       log.info('Generating json feed')
       await fs.outputFile(
-        api.resolveCwd(`.saber/public/${feedLinks.json.replace(siteConfig.url, '')}`),
+        api.resolveCwd(
+          `.saber/public/${feedLinks.json.replace(siteConfig.url, '')}`
+        ),
         feed.json1(),
         'utf8'
       )
@@ -89,7 +93,9 @@ exports.apply = (api, options = {}) => {
     if (feedLinks.atom || feedLinks.rss2) {
       log.info('Generating xml feed')
       await fs.outputFile(
-        api.resolveCwd(`.saber/public/${feedLinks.atom.replace(siteConfig.url, '')}`),
+        api.resolveCwd(
+          `.saber/public/${feedLinks.atom.replace(siteConfig.url, '')}`
+        ),
         feed.atom1(),
         'utf8'
       )
@@ -99,7 +105,7 @@ exports.apply = (api, options = {}) => {
   api.hooks.defineVariables.tap(ID, variables => {
     return Object.assign(variables, {
       feed: true,
-      feedLinks: feedLinks
+      feedLinks
     })
   })
 }

--- a/packages/saber-plugin-generate-feed/lib/utils.js
+++ b/packages/saber-plugin-generate-feed/lib/utils.js
@@ -1,0 +1,17 @@
+// @ts-check
+/**
+ * Get feed path
+ * @param {string|boolean|undefined} feedPath
+ * @param {string} defaultPath
+ */
+exports.getFeedPath = (feedPath, defaultPath) => {
+  if (feedPath === true) {
+    return defaultPath
+  }
+
+  if (typeof feedPath === 'string') {
+    return feedPath
+  }
+
+  return null
+}

--- a/packages/saber-plugin-generate-feed/package.json
+++ b/packages/saber-plugin-generate-feed/package.json
@@ -6,5 +6,9 @@
   "files": [
     "lib"
   ],
-  "xo": false
+  "xo": false,
+  "dependencies": {
+    "feed": "^2.0.4",
+    "url-join": "^4.0.0"
+  }
 }

--- a/packages/saber-plugin-generate-feed/package.json
+++ b/packages/saber-plugin-generate-feed/package.json
@@ -3,12 +3,14 @@
   "version": "0.0.4",
   "license": "MIT",
   "main": "lib/index.js",
+  "scripts": {
+    "generate:example": "saber generate example"
+  },
   "files": [
     "lib"
   ],
   "xo": false,
   "dependencies": {
-    "feed": "^2.0.4",
-    "url-join": "^4.0.0"
+    "feed": "^2.0.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,12 @@
     "strict": true,
     "allowJs": true,
     "noEmit": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "module": "commonjs",
     "target": "es2015",
-    "outDir": "dist",
     "esModuleInterop": true,
-    "moduleResolution": "node"
-  },
-  "include": ["lib/**/*"]
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noUnusedParameters": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,6 +4182,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+feed@^2.0.4:
+  version "2.0.4"
+  resolved "http://registry.npm.taobao.org/feed/download/feed-2.0.4.tgz#14cd71b3bae1e965b81f7e0c5927e8941de996f8"
+  integrity sha1-FM1xs7rh6WW4H34MWSfolB3plvg=
+  dependencies:
+    luxon "^1.3.3"
+    xml "^1.0.1"
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -6736,6 +6744,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+luxon@^1.3.3:
+  version "1.12.0"
+  resolved "http://registry.npm.taobao.org/luxon/download/luxon-1.12.0.tgz#d02d53c8d8aaebe6b4c00ba1ce1be3913546b2e7"
+  integrity sha1-0C1TyNiq6+a0wAuhzhvjkTVGsuc=
 
 magic-string@^0.25.1:
   version "0.25.1"
@@ -10879,6 +10892,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "http://registry.npm.taobao.org/xml/download/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xo-init@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR has BREAKING CHANGES.

- Using [feed](https://github.com/jpmonette/feed) library to generate feed. Support atom and rss2 type of feed (both are xml format, rss2 uses atom format to generate).
- Now users can specific the path of the feed. For example, `saber-config.js`:
  ```js
  resolve: 'saber-plugin-generate-feed',
  options: {
    feeds: {
      json: '/feed.json',
      atom: '/blog/atom.xml'
    }
  }
  ```
- Exposing `feedUrl` variable has been moved to `feedLinks` object. (BREAKING CHANGE)
