### PR TITLE
fix: beforeEnter hook

### DIFF
--- a/packages/saber/vue-renderer/app/create-app.js
+++ b/packages/saber/vue-renderer/app/create-app.js
@@ -53,8 +53,8 @@ export default context => {
           delete transition[key]
         }
       })
-      const { beforeEnter } = listeners
-      listeners.beforeEnter = el => {
+      const beforeEnter = listeners['before-enter']
+      listeners['before-enter'] = el => {
         this.$emit('trigger-scroll')
         beforeEnter && beforeEnter(el)
       }


### PR DESCRIPTION
I noticed that the `beforeEnter` page transition hook was not called. This was happening because kebab and camel case were mixed up.