### PR TITLE
fix: render error for pages with no defaultSlot

### DIFF
--- a/packages/saber/vue-renderer/app/LayoutManager.vue
+++ b/packages/saber/vue-renderer/app/LayoutManager.vue
@@ -30,7 +30,7 @@ export default {
       console.error(`Cannot find layout component "${layout}" in `, layouts)
     }
 
-    return h(LayoutComponent, attrs, componentSlot ? componentSlot(attrs.props) : defaultSlot())
+    return h(LayoutComponent, attrs, componentSlot ? componentSlot(attrs.props) : defaultSlot ? defaultSlot() : null)
   }
 }
 </script>

--- a/packages/saber/vue-renderer/app/LayoutManager.vue
+++ b/packages/saber/vue-renderer/app/LayoutManager.vue
@@ -30,7 +30,7 @@ export default {
       console.error(`Cannot find layout component "${layout}" in `, layouts)
     }
 
-    return h(LayoutComponent, attrs, componentSlot ? componentSlot(attrs.props) : defaultSlot ? defaultSlot() : null)
+    return h(LayoutComponent, attrs, componentSlot ? componentSlot(attrs.props) : defaultSlot ? defaultSlot() : undefined)
   }
 }
 </script>


### PR DESCRIPTION
Pages without a defaultSlot and componentSlot, like these:

```md
---
injectAllPosts: true
layout: home
---

```

caused a render error `TypeError: defaultSlot is not a function` with https://github.com/egoist/saber/commit/714bb22813b3a8ef308566e4aa3907e568c422d2, specifically by:

https://github.com/egoist/saber/blob/889a26947dab92c1693679366307eddc3b934040/packages/saber/vue-renderer/app/LayoutManager.vue#L33

The saber.land website is also affected once it gets rebuilt, as the `/blog/` route only consists of an "empty" markdown file:

https://github.com/egoist/saber/blob/0f65ca878b64c5046a071ba9d8a759bb7429038e/website/pages/blog/index.md#L1-L5