### PR TITLE
fix: invalid URL error

### DIFF
--- a/packages/saber/vue-renderer/lib/index.js
+++ b/packages/saber/vue-renderer/lib/index.js
@@ -422,7 +422,7 @@ class VueRenderer {
         return render()
       }
 
-      const pathname = req.path
+      const pathname = decodeURI(req.path)
 
       if (this.builtRoutes.has(pathname)) {
         render()

--- a/packages/saber/vue-renderer/lib/index.js
+++ b/packages/saber/vue-renderer/lib/index.js
@@ -422,10 +422,7 @@ class VueRenderer {
         return render()
       }
 
-      const queryPosition = req.url.indexOf('?')
-      const pathname = decodeURI(
-        queryPosition === -1 ? req.url : req.url.slice(0, queryPosition)
-      )
+      const pathname = req.path
 
       if (this.builtRoutes.has(pathname)) {
         render()

--- a/packages/saber/vue-renderer/lib/index.js
+++ b/packages/saber/vue-renderer/lib/index.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { EventEmitter } = require('events')
-const url = require('url')
 const { fs, slash } = require('saber-utils')
 const { log } = require('saber-log')
 
@@ -423,7 +422,10 @@ class VueRenderer {
         return render()
       }
 
-      const pathname = decodeURI(new url.URL(req.url).pathname)
+      const queryPosition = req.url.indexOf('?')
+      const pathname = decodeURI(
+        queryPosition === -1 ? req.url : req.url.slice(0, queryPosition)
+      )
 
       if (this.builtRoutes.has(pathname)) {
         render()


### PR DESCRIPTION
e596812f21aefc8b0206883f61af257bfa51b5a4 introduced an issue by swapping deprecated `url.parse()` for the newer WHATWG api:

https://github.com/egoist/saber/blob/e596812f21aefc8b0206883f61af257bfa51b5a4/packages/saber/vue-renderer/lib/index.js#L420

`req.url` is a relative URL. Unfortunately, the new API only works with absolute URLs and throws an error whenever an invalid URL is passed - a relative URL is invalid. Thrown error means Saber crashes. See https://nodejs.org/api/url.html#url_constructor_new_url_input_base for more info.
